### PR TITLE
Verbiage Change in Bspwm Keybindings Page

### DIFF
--- a/src/content/docs/en/configuration/bspwm.mdx
+++ b/src/content/docs/en/configuration/bspwm.mdx
@@ -70,7 +70,7 @@ Select your favourite and press **Enter**.
 
 ## Keybindings
 
-Here are reported some useful **keybindings** set by default in Athena OS GNOME.
+Here are reported some useful **keybindings** set by default in Athena OS Bspwm.
 
 ### Application and System Management
 


### PR DESCRIPTION
- Changed verbiage where it incorrectly states the keybindings are for GNOME instead of the correct TWM of Bspwm. 