### PR TITLE
Add "Submitting Tools in Nix" and "Submitting Tools in Arch" links

### DIFF
--- a/src/content/docs/en/community/contribute.mdx
+++ b/src/content/docs/en/community/contribute.mdx
@@ -26,7 +26,7 @@ The BTP are set on Athena OS Discord channel. If you would like to belong to the
 
 If you would like to be a tool maintainer by keeping updated existing packages or you are a pentesting tool developer, you can enrich the existing tool repositories in order to contribute not only to Athena OS, but to the **entire Arch and Nix ecosystems**.
 
-Are you excited for this? Just follow the [Submitting Tools in Arch](/src/content/docs/en/community/submitting-tools-arch.mdx) or [Submitting Tools in Nix] (/src/content/docs/en/community/submitting-tools-nix.mdx)sections.
+Are you excited for this? Just follow the [Submitting Tools in Arch](/src/content/docs/en/community/submitting-tools-arch.mdx) or [Submitting Tools in Nix] (/src/content/docs/en/community/submitting-tools-nix.mdx) sections.
 
 ## Documentation
 

--- a/src/content/docs/en/community/contribute.mdx
+++ b/src/content/docs/en/community/contribute.mdx
@@ -26,7 +26,7 @@ The BTP are set on Athena OS Discord channel. If you would like to belong to the
 
 If you would like to be a tool maintainer by keeping updated existing packages or you are a pentesting tool developer, you can enrich the existing tool repositories in order to contribute not only to Athena OS, but to the **entire Arch and Nix ecosystems**.
 
-Are you excited for this? Just follow the [Submitting Tools](/en/community/submitting-tools/) section.
+Are you excited for this? Just follow the [Submitting Tools in Arch](/src/content/docs/en/community/submitting-tools-arch.mdx) or [Submitting Tools in Nix] (/src/content/docs/en/community/submitting-tools-nix.mdx)sections.
 
 ## Documentation
 

--- a/src/content/docs/en/community/contribute.mdx
+++ b/src/content/docs/en/community/contribute.mdx
@@ -26,7 +26,7 @@ The BTP are set on Athena OS Discord channel. If you would like to belong to the
 
 If you would like to be a tool maintainer by keeping updated existing packages or you are a pentesting tool developer, you can enrich the existing tool repositories in order to contribute not only to Athena OS, but to the **entire Arch and Nix ecosystems**.
 
-Are you excited for this? Just follow the [Submitting Tools in Arch](/src/content/docs/en/community/submitting-tools-arch.mdx) or [Submitting Tools in Nix] (/src/content/docs/en/community/submitting-tools-nix.mdx) sections.
+Are you excited for this? Just follow the [Submitting Tools in Arch](/src/content/docs/en/community/submitting-tools-arch.mdx) or [Submitting Tools in Nix](/src/content/docs/en/community/submitting-tools-nix.mdx) sections.
 
 ## Documentation
 


### PR DESCRIPTION
Hi,

I correct the section "Pentesting tools" in the page "Contribute to Athena".

The link leads to a 404, so I add the correct links for the "Submitting Tools in Nix" and "Submitting Tools in Arch" pages. 

